### PR TITLE
Use getHeader() method instead of fetching from an array.

### DIFF
--- a/src/Redirects.php
+++ b/src/Redirects.php
@@ -16,7 +16,7 @@ class Redirects extends Module{
 	{
 		$response       = $this->getModule('PhpBrowser')->client->getInternalResponse();
 		$responseCode   = $response->getStatus();
-		$locationHeader = $response->getHeaders()[ 'Location' ][ 0 ];
+		$locationHeader = $response->getHeader('Location', true);
 
 		// Check for 301 response code.
 		$this->assertEquals(301, $responseCode);


### PR DESCRIPTION
Instead of using `getHeaders()`, retrieving all of them, and then fetching from the array, it would be preferable to use `getHeader()` method with the requested header name, and pass it the option `$first = true`.
