### PR TITLE
Test redirects by specified HTTP status code

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ $I->followRedirects(false);
 Check that the specified HTTP Status is returned with the correct Location URL. Fails if either is missing, or `Location` header value does not match the `$url`. Automatically avoids following redirects.
 
 ```php
-$I->seeRedirectBetween('company/financial-strength-and-security.cfm', 'company/financial-security', 302 );
+$I->seeRedirectBetween('company/financial-strength-and-security.cfm', 'company/financial-security', 302);
 ```
 
 * `param` **`$oldUrl`**

--- a/README.md
+++ b/README.md
@@ -159,9 +159,27 @@ $I->followRedirects(false);
 
     Whether to follow automatic redirects or not. Default behaviour is true, so most times you'll want to pass in false for 301 redirects tests. Other methods in this package already call this as needed.
 
+### seeRedirectBetween
+
+Check that the specified HTTP Status is returned with the correct Location URL. Fails if either is missing, or `Location` header value does not match the `$url`. Automatically avoids following redirects.
+
+```php
+$I->seeRedirectBetween('company/financial-strength-and-security.cfm', 'company/financial-security', 302 );
+```
+
+* `param` **`$oldUrl`**
+
+    Relative or absolute URL that should be redirected.
+* `param` **`$newUrl`**
+
+    Relative or absolute URL of redirect destination.
+* `param` **`$statusCode`**
+
+    HTTP status code to check for.
+
 ### seePermanentRedirectBetween
 
-Check that a 301 HTTP Status is returned with the correct Location URL. Fails if either is missing, or `Location` header value does not match the `$url`. Automatically avoids following redirects.
+A convenience method to check that a 301 HTTP Status is returned with the correct Location URL. Fails if either is missing, or `Location` header value does not match the `$url`. Automatically avoids following redirects.
 
 ```php
 $I->seePermanentRedirectBetween('company/financial-strength-and-security.cfm', 'company/financial-security');
@@ -176,7 +194,7 @@ $I->seePermanentRedirectBetween('company/financial-strength-and-security.cfm', '
     
 ### seeTemporaryRedirectBetween
 
-Check that a 307 HTTP Status is returned with the correct Location URL. Fails if either is missing, or `Location` header value does not match the `$url`. Automatically avoids following redirects.
+A convenience method to check that a 307 HTTP Status is returned with the correct Location URL. Fails if either is missing, or `Location` header value does not match the `$url`. Automatically avoids following redirects.
 
 ```php
 $I->seeTemporaryRedirectBetween('company/financial-strength-and-security.cfm', 'company/financial-security');

--- a/src/Redirects.php
+++ b/src/Redirects.php
@@ -86,6 +86,18 @@ class Redirects extends Module
         $this->seeRedirectBetween($oldUrl, $newUrl, 307);
     }
 
+	/**
+	 * Check that the specified HTTP Status is returned with the correct Location URL.
+	 *
+	 * @param string $oldUrl     Relative or absolute URL that should be redirected.
+	 * @param string $newUrl     Relative or absolute URL of redirect destination.
+	 * @param int    $statusCode HTTP Status code to check against.
+	 */
+	public function seeOtherRedirectBetween($oldUrl, $newUrl, $statusCode)
+	{
+		$this->seeRedirectBetween($oldUrl, $newUrl, $statusCode);
+	}
+
     /**
      * Check that a redirection occurs.
      *

--- a/src/Redirects.php
+++ b/src/Redirects.php
@@ -60,8 +60,41 @@ class Redirects extends Module
         return $this->getModule('PhpBrowser')->client->isFollowingRedirects();
     }
 
+	/**
+	 * Check that a redirection occurs.
+	 *
+	 * @since 0.2.0
+	 *
+	 * @param string  $oldUrl     Relative or absolute URL that should be redirected.
+	 * @param string  $newUrl     Relative or absolute URL of redirect destination.
+	 * @param integer $statusCode Status code to check for.
+	 */
+	public function seeRedirectBetween($oldUrl, $newUrl, $statusCode)
+	{
+		// We must not follow all redirects, so save current situation,
+		// force disable follow redirects, and revert at the end.
+		$followsRedirects = $this->isFollowingRedirects();
+		$this->followRedirects(false);
+
+		$response = $this->sendHeadAndGetResponse($oldUrl);
+
+		if (null !== $response) {
+			$responseCode   = $response->getStatus();
+			$locationHeader = $response->getHeader('Location', true);
+
+			// Check for correct response code.
+			$this->assertEquals($statusCode, $responseCode, 'Response code was not ' . $statusCode . '.');
+
+			// Check location header URL contains submitted URL.
+			$this->assertContains($newUrl, $locationHeader, 'Redirect destination not found in Location header.');
+		}
+
+
+		$this->followRedirects($followsRedirects);
+	}
+
     /**
-     * Check that a 301 HTTP Status is returned with the correct Location URL.
+     * Convenience method to check that a 301 HTTP Status is returned with the correct Location URL.
      *
      * @since 0.2.0
      *
@@ -74,7 +107,7 @@ class Redirects extends Module
     }
 
     /**
-     * Check that a 307 HTTP Status is returned with the correct Location URL.
+     * Convenience method to check that a 307 HTTP Status is returned with the correct Location URL.
      *
      * @since 0.3.0
      *
@@ -84,51 +117,6 @@ class Redirects extends Module
     public function seeTemporaryRedirectBetween($oldUrl, $newUrl)
     {
         $this->seeRedirectBetween($oldUrl, $newUrl, 307);
-    }
-
-	/**
-	 * Check that the specified HTTP Status is returned with the correct Location URL.
-	 *
-	 * @param string $oldUrl     Relative or absolute URL that should be redirected.
-	 * @param string $newUrl     Relative or absolute URL of redirect destination.
-	 * @param int    $statusCode HTTP Status code to check against.
-	 */
-	public function seeOtherRedirectBetween($oldUrl, $newUrl, $statusCode)
-	{
-		$this->seeRedirectBetween($oldUrl, $newUrl, $statusCode);
-	}
-
-    /**
-     * Check that a redirection occurs.
-     *
-     * @since 0.2.0
-     *
-     * @param string  $oldUrl     Relative or absolute URL that should be redirected.
-     * @param string  $newUrl     Relative or absolute URL of redirect destination.
-     * @param integer $statusCode Status code to check for.
-     */
-    protected function seeRedirectBetween($oldUrl, $newUrl, $statusCode)
-    {
-        // We must not follow all redirects, so save current situation,
-        // force disable follow redirects, and revert at the end.
-        $followsRedirects = $this->isFollowingRedirects();
-        $this->followRedirects(false);
-
-        $response = $this->sendHeadAndGetResponse($oldUrl);
-
-        if (null !== $response) {
-            $responseCode   = $response->getStatus();
-            $locationHeader = $response->getHeader('Location', true);
-
-            // Check for correct response code.
-            $this->assertEquals($statusCode, $responseCode, 'Response code was not ' . $statusCode . '.');
-
-            // Check location header URL contains submitted URL.
-            $this->assertContains($newUrl, $locationHeader, 'Redirect destination not found in Location header.');
-        }
-
-
-        $this->followRedirects($followsRedirects);
     }
 
     /**


### PR DESCRIPTION
Simplifies testing additional HTTP status codes, such as `302` and `303`.

Closes #9